### PR TITLE
dispose loaded components once listed

### DIFF
--- a/src/protocol/Component.coffee
+++ b/src/protocol/Component.coffee
@@ -37,8 +37,10 @@ class ComponentProtocol
       unless instance.isReady()
         instance.once 'ready', =>
           @sendComponent component, instance, context
+          instance.shutdown()
         return
       @sendComponent component, instance, context
+      instance.shutdown()
     , true
 
   sendComponent: (component, instance, context) ->


### PR DESCRIPTION
Some of the components don't have any input port and just emit some IPs (for example with a timeout or an event callback on a canvas/scenegraph).
It would save some resources to dispose these instances as they were just used to list the available components and theirs ports at the beginning of the connection of the web UI.
