### PR TITLE
Filter data sent from the runtime to the web UI

### DIFF
--- a/src/protocol/Network.coffee
+++ b/src/protocol/Network.coffee
@@ -74,9 +74,14 @@ class NetworkProtocol
 
   updateEdgesFilter: (graph, payload, context) ->
     network = @networks[payload.graph]
-    return unless network
+    if network
+      network.filters = {}
+    else
+      network =
+        network: null
+        filters: {}
+      @networks[payload.graph] = network
 
-    network.filters = {}
     for edge in payload.edges
       signature = getEdgeSignature(edge)
       log('add signature : ' + signature)
@@ -92,9 +97,12 @@ class NetworkProtocol
   initNetwork: (graph, payload, context) ->
     graph.componentLoader = @transport.component.getLoader graph.baseDir
     noflo.createNetwork graph, (network) =>
-      @networks[payload.graph] =
-        network: network
-        filters: {}
+      if @networks[payload.graph]
+        @networks[payload.graph].network = network
+      else
+        @networks[payload.graph] =
+          network: network
+          filters: {}
       @subscribeNetwork network, payload, context
 
       # Run the network


### PR DESCRIPTION
While building my application using the web UI, I've noticed that the web UI ends up being completely blocked.
It turns out that the runtime is spamming the web UI because it is sending all data transmitted through the entire graph.

The web UI already sends the edges it is monitoring. Using that information, we can filter the data sent to the UI.
