### PR TITLE
Use more options given to Base transport class

### DIFF
--- a/src/protocol/Runtime.coffee
+++ b/src/protocol/Runtime.coffee
@@ -18,16 +18,19 @@ class RuntimeProtocol
         type = 'noflo-browser'
       else
         type = 'noflo-nodejs'
-    @send 'runtime',
-      type: type
-      version: @transport.version
-      capabilities: [
+    capabilities = @transport.options.capabilities
+    unless capabilities
+      capabilities = [
         'protocol:graph'
         'protocol:component'
         'protocol:network'
         'component:setsource'
         'component:getsource'
       ]
+    @send 'runtime',
+      type: type
+      version: @transport.version
+      capabilities: capabilities
     , context
 
   receivePacket: (payload, context) ->


### PR DESCRIPTION
In order to make the runtime base more flexible with external options, the inner classes can use the options given to the base transport class.
