### PR TITLE
add changenode support

### DIFF
--- a/src/protocol/Graph.coffee
+++ b/src/protocol/Graph.coffee
@@ -18,6 +18,7 @@ class GraphProtocol
       when 'addnode' then @addNode graph, payload, context
       when 'removenode' then @removeNode graph, payload, context
       when 'renamenode' then @renameNode graph, payload, context
+      when 'changenode' then @changeNode graph, payload, context
       when 'addedge' then @addEdge graph, payload, context
       when 'removeedge' then @removeEdge graph, payload, context
       when 'addinitial' then @addInitial graph, payload, context
@@ -76,6 +77,12 @@ class GraphProtocol
         to: newId
         graph: id
       , context
+    graph.on 'changeNode', (node, before) =>
+      @send 'changenode',
+        id: node.id
+        metadata: node.metadata
+        graph: id
+      , context
     graph.on 'addEdge', (edge) =>
       delete edge.from.index unless typeof edge.from.index is 'number'
       delete edge.to.index unless typeof edge.to.index is 'number'
@@ -124,6 +131,12 @@ class GraphProtocol
       @send 'error', new Error('No from or to supplied'), context
       return
     graph.renameNode payload.from, payload.to
+
+  changeNode: (graph, payload, context) ->
+    unless payload.id or payload.metadata
+      @send 'error', new Error('No id or metadata supplied'), context
+      return
+    graph.setNodeMetadata payload.id, payload.metadata
 
   addEdge: (graph, edge, context) ->
     unless edge.src or edge.tgt


### PR DESCRIPTION
The runtimes are already receiving metadata about the positions of the nodes on the UI's canvas.
This is just enabling the runtime to actually receive these informations in order to store all that data when needed.
