### PR TITLE
Network: use start() instead of sendInitials()

### DIFF
--- a/src/protocol/Network.coffee
+++ b/src/protocol/Network.coffee
@@ -68,7 +68,7 @@ class NetworkProtocol
 
       # Run the network
       network.connect ->
-        network.sendInitials()
+        network.start()
         graph.on 'addInitial', ->
           network.sendInitials()
     , true


### PR DESCRIPTION
Following https://github.com/noflo/noflo/commit/2cbadc4bd3990be3d0ae6cb9b5cb7de0604b6419 runtime-base should use start() instead of sendInitials() to start the network.
