### PR TITLE
Network: add support for monitoring errors in processes

### DIFF
--- a/src/protocol/Network.coffee
+++ b/src/protocol/Network.coffee
@@ -66,6 +66,8 @@ class NetworkProtocol
         @stopNetwork graph, payload, context
       when 'edges'
         @updateEdgesFilter graph, payload, context
+      when 'debug'
+        @debugNetwork graph, payload, context
 
   resolveGraph: (payload, context) ->
     unless payload.graph
@@ -139,9 +141,15 @@ class NetworkProtocol
         uptime: event.uptime
         graph: payload.graph
       , context
+    network.on 'process-error', (event) =>
+      @send 'processerror', event, context
 
   stopNetwork: (graph, payload, context) ->
     return unless @networks[payload.graph]
     @networks[payload.graph].network.stop()
+
+  debugNetwork: (graph, payload, context) ->
+    return unless @networks[payload.graph]
+    @networks[payload.graph].network.setDebug payload.enable
 
 module.exports = NetworkProtocol


### PR DESCRIPTION
Making use of https://github.com/noflo/noflo/pull/253, this is the runtime side of things to expose errors in processes to the UI.
