### PR TITLE
Network: processerror: add graph identifier in the command

### DIFF
--- a/src/protocol/Network.coffee
+++ b/src/protocol/Network.coffee
@@ -142,7 +142,11 @@ class NetworkProtocol
         graph: payload.graph
       , context
     network.on 'process-error', (event) =>
-      @send 'processerror', event, context
+      @send 'processerror',
+        id: event.id
+        error: event.error
+        graph: payload.graph
+      , context
 
   stopNetwork: (graph, payload, context) ->
     return unless @networks[payload.graph]


### PR DESCRIPTION
Small update to indicate the associated graph to a process error command.
