### PR TITLE
Trace right event names for groups

### DIFF
--- a/src/trace.coffee
+++ b/src/trace.coffee
@@ -67,9 +67,9 @@ class Tracer
     debug 'attach', netId
     eventNames = [
       'connect'
-      'beginGroup'
+      'begingroup'
       'data'
-      'endGroup'
+      'endgroup'
       'disconnect'
     ]
     eventNames.forEach (event) =>


### PR DESCRIPTION
It was a typo, make it possible to trace begin/end groups

![2015-12-01-171857_634x107_scrot](https://cloud.githubusercontent.com/assets/49062/11511359/d83b1256-984f-11e5-9e0c-f867b2345c86.png)
