### PR TITLE
Update Graph.coffee: Introduced a graph:list command

### DIFF
--- a/src/protocol/Graph.coffee
+++ b/src/protocol/Graph.coffee
@@ -16,12 +16,13 @@ class GraphProtocol
       return
 
     # Find locally stored graph by ID
-    if topic isnt 'clear'
+    if topic isnt 'clear' && topic isnt 'list'
       graph = @resolveGraph payload, context
       return unless graph
 
     switch topic
       when 'clear' then @initGraph payload, context
+      when 'list' then @listGraphs payload, context
       when 'addnode' then @addNode graph, payload, context
       when 'removenode' then @removeNode graph, payload, context
       when 'renamenode' then @renameNode graph, payload, context
@@ -213,6 +214,14 @@ class GraphProtocol
         #metadata: port.metadata
       @sendAll 'removeoutport', data, context
 
+  listGraphs: (payload, context) ->
+    graphNames = []
+    for graphName,v of @graphs
+      graphNames.push(graphName)
+    
+    @send 'list', {"graphs":graphNames}, context
+    return
+      
   addNode: (graph, node, context) ->
     unless node.id or node.component
       @send 'error', new Error('No ID or component supplied'), context


### PR DESCRIPTION
This commit introduces a command which lists all graphs which were created through the fbp protocol in a runtime. 

It's needed for UIs to get an overview of which graphs are available (for dynamically subgraphing, deleting, ...).

Is related to this issue:
https://github.com/noflo/noflo/issues/512