### PR TITLE
Make runtime ports/packets accessible in JS

### DIFF
--- a/spec/Runtime.coffee
+++ b/spec/Runtime.coffee
@@ -148,7 +148,7 @@ describe 'Runtime protocol', ->
         return unless msg.event is 'data'
         chai.expect(msg.payload).to.eql payload
         done()
-      runtime.runtime.receivePacket
+      runtime.runtime.sendPacket
         graph: 'bar'
         port: 'in'
         event: 'data'

--- a/spec/Runtime.coffee
+++ b/spec/Runtime.coffee
@@ -101,8 +101,8 @@ describe 'Runtime protocol', ->
         graph: 'bar'
         secret: 'second-secret'
       client.send 'graph', 'addoutport',
-        public: 'in'
-        node: 'Hello'
+        public: 'out'
+        node: 'World'
         port: 'out'
         graph: 'bar'
         secret: 'second-secret'
@@ -126,6 +126,7 @@ describe 'Runtime protocol', ->
       messageListener = (msg) ->
         return unless msg.protocol is 'runtime'
         return unless msg.command is 'packet'
+        return unless msg.payload.port is 'out'
         return unless msg.payload.event is 'data'
         chai.expect(msg.payload.payload).to.eql payload
         client.removeListener 'message', messageListener

--- a/src/protocol/Runtime.coffee
+++ b/src/protocol/Runtime.coffee
@@ -48,15 +48,11 @@ class RuntimeProtocol extends EventEmitter
 
       if network.isStarted()
         # processes don't exist until started
-        @emit 'ports',
-          graph: name
-          ports: portsPayload network.graph
+        @emit 'ports', portsPayload name, network.graph
         @subscribeOutdata name, network, true
       network.on 'start', () =>
         # processes don't exist until started
-        @emit 'ports',
-          graph: name
-          ports: portsPayload network.graph
+        @emit 'ports', portsPayload name, network.graph
         @subscribeOutdata name, network, true
 
     @transport.network.on 'removenetwork', (network, name) =>
@@ -64,9 +60,7 @@ class RuntimeProtocol extends EventEmitter
       @subscribeOutPorts name, network
       @subscribeExportedPorts name, network.graph, false
       @sendPorts name, null
-      @emit 'ports',
-        graph: name
-        ports: portsPayload network.graph
+      @emit 'ports', portsPayload name, network.graph
 
   send: (topic, payload, context) ->
     @transport.send 'runtime', topic, payload, context
@@ -200,12 +194,12 @@ class RuntimeProtocol extends EventEmitter
       component.outPorts[internal.port].attach socket
       sendFunc = (event) =>
         (payload) =>
-          @sendAll 'packet',
+          @emit 'packet',
             port: pub
             event: event
             graph: graphName
             payload: payload
-          @emit 'packet',
+          @sendAll 'packet',
             port: pub
             event: event
             graph: graphName

--- a/src/protocol/Runtime.coffee
+++ b/src/protocol/Runtime.coffee
@@ -21,8 +21,8 @@ findPort = (network, name, inPort) ->
   return unless internal?.process
   component = network.getNode(internal.process)?.component
   return unless component
-  return component.inPorts[name] if inPort
-  return component.outPorts[name]
+  return component.inPorts[internal.port] if inPort
+  return component.outPorts[internal.port]
 
 portToPayload = (pub, internal, network, inPort) ->
   def =

--- a/src/protocol/Runtime.coffee
+++ b/src/protocol/Runtime.coffee
@@ -95,7 +95,7 @@ class RuntimeProtocol extends EventEmitter
 
     switch topic
       when 'getruntime' then @getRuntime payload, context
-      when 'packet' then @receivePacket payload, (err) =>
+      when 'packet' then @sendPacket payload, (err) =>
         if err
           @sendError err.message, context
         return
@@ -224,7 +224,7 @@ class RuntimeProtocol extends EventEmitter
       for event in events
         socket.on event, sendFunc event
 
-  receivePacket: (payload, callback) ->
+  sendPacket: (payload, callback) ->
     network = @transport.network.networks[payload.graph]
     return callback new Error "Cannot find network for graph #{payload.graph}" if not network
     port = findPort network.network, payload.port, true

--- a/src/protocol/Runtime.coffee
+++ b/src/protocol/Runtime.coffee
@@ -65,11 +65,9 @@ class RuntimeProtocol extends EventEmitter
 
       if network.isStarted()
         # processes don't exist until started
-        @emit 'ports', portsPayload name, network
         @subscribeOutdata name, network, true
       network.on 'start', () =>
         # processes don't exist until started
-        @emit 'ports', portsPayload name, network
         @subscribeOutdata name, network, true
 
     @transport.network.on 'removenetwork', (network, name) =>
@@ -77,7 +75,6 @@ class RuntimeProtocol extends EventEmitter
       @subscribeOutPorts name, network
       @subscribeExportedPorts name, network.graph, false
       @sendPorts name, null
-      @emit 'ports', portsPayload name, network
 
   send: (topic, payload, context) ->
     @transport.send 'runtime', topic, payload, context
@@ -143,6 +140,7 @@ class RuntimeProtocol extends EventEmitter
 
   sendPorts: (name, network, context) ->
     payload = portsPayload name, network
+    @emit 'ports', payload
     if not context
       @sendAll 'ports', payload
     else


### PR DESCRIPTION
The idea here is that developers can start a NoFlo runtime accessible from remote fbp protocol clients, but _also_ communicate with the runtime main graph ports on JS level