### PR TITLE
Provide error and ready events

### DIFF
--- a/spec/Base.coffee
+++ b/spec/Base.coffee
@@ -1,0 +1,36 @@
+noflo = require 'noflo'
+
+if noflo.isBrowser()
+  direct = require('noflo-runtime-base').direct
+  baseDir = 'noflo-runtime-base'
+else
+  chai = require 'chai' unless chai
+  direct = require '../direct'
+  path = require 'path'
+  baseDir = path.resolve __dirname, '../'
+
+describe 'Base interface', ->
+  describe 'with a working default graph', ->
+    it 'should register and run a network', (done) ->
+      graphData =
+        processes:
+          Node1:
+            component: 'core/Repeat'
+        connections: [
+          data: 'My message to print'
+          tgt:
+            process: 'Node1'
+            port: 'in'
+        ]
+      startReceived = false
+      noflo.graph.loadJSON graphData, (err, graph) ->
+        return done err if err
+        rt = new direct.Runtime
+          defaultGraph: graph
+          baseDir: baseDir
+        rt.network.on 'addnetwork', (network) ->
+          network.on 'start', ->
+            startReceived = true
+          network.on 'end', ->
+            chai.expect(startReceived, 'should have received start').to.equal true
+            done()

--- a/spec/Base.coffee
+++ b/spec/Base.coffee
@@ -10,6 +10,13 @@ else
   baseDir = path.resolve __dirname, '../'
 
 describe 'Base interface', ->
+  describe 'without a graph', ->
+    it 'should become ready without network', (done) ->
+      rt = new direct.Runtime
+        baseDir: baseDir
+      rt.on 'ready', (net) ->
+        chai.expect(net).to.equal null
+        done()
   describe 'with a working default graph', ->
     it 'should register and run a network', (done) ->
       graphData =
@@ -22,15 +29,41 @@ describe 'Base interface', ->
             process: 'Node1'
             port: 'in'
         ]
+      readyReceived = false
       startReceived = false
       noflo.graph.loadJSON graphData, (err, graph) ->
         return done err if err
         rt = new direct.Runtime
           defaultGraph: graph
           baseDir: baseDir
+        rt.on 'ready', (net) ->
+          chai.expect(net).to.be.instanceof noflo.Network
+          readyReceived = true
         rt.network.on 'addnetwork', (network) ->
           network.on 'start', ->
             startReceived = true
           network.on 'end', ->
+            chai.expect(readyReceived, 'should have received ready').to.equal true
             chai.expect(startReceived, 'should have received start').to.equal true
             done()
+  describe 'with a graph containing a faulty IIP', ->
+    it 'should emit an error', (done) ->
+      graphData =
+        processes:
+          Node1:
+            component: 'core/Repeat'
+        connections: [
+          data: 'My message to print'
+          tgt:
+            process: 'Node1'
+            port: 'missing'
+        ]
+      noflo.graph.loadJSON graphData, (err, graph) ->
+        return done err if err
+        rt = new direct.Runtime
+          defaultGraph: graph
+          baseDir: baseDir
+        rt.on 'error', (err) ->
+          chai.expect(err).to.be.an 'error'
+          console.log err.message
+          done()

--- a/src/Base.coffee
+++ b/src/Base.coffee
@@ -21,14 +21,6 @@ class BaseTransport
     @runtime = new protocols.Runtime @
     @context = null
 
-    if @options.defaultGraph?
-      @options.defaultGraph.baseDir = @options.baseDir
-      graphName = 'default/main'
-      @context = 'none'
-      @graph.registerGraph graphName, @options.defaultGraph
-      @network._startNetwork @options.defaultGraph, graphName, @context, (err) ->
-        throw err if err
-
     if @options.captureOutput? and @options.captureOutput
       # Start capturing so that we can send it to the UI when it connects
       @startCapture()
@@ -53,6 +45,19 @@ class BaseTransport
 
     unless @options.permissions
       @options.permissions = {}
+
+    if @options.defaultGraph?
+      setTimeout =>
+        @_startDefaultGraph()
+      , 0
+
+  _startDefaultGraph: () ->
+    @options.defaultGraph.baseDir = @options.baseDir
+    graphName = 'default/main'
+    @context = 'none'
+    @graph.registerGraph graphName, @options.defaultGraph
+    @network._startNetwork @options.defaultGraph, graphName, @context, (err) ->
+      throw err if err
 
   # Check if a given user is authorized for a given capability
   #

--- a/src/protocol/Network.coffee
+++ b/src/protocol/Network.coffee
@@ -199,7 +199,9 @@ class NetworkProtocol extends EventEmitter
 
   _startNetwork: (graph, graphName, context, callback) ->
     doStart = (net) ->
-      net.start callback
+      net.start (err) ->
+        return callback err if err
+        callback null, net
 
     network = @networks[graphName]
     if network and network.network

--- a/src/protocol/Network.coffee
+++ b/src/protocol/Network.coffee
@@ -199,8 +199,7 @@ class NetworkProtocol extends EventEmitter
 
   _startNetwork: (graph, graphName, context, callback) ->
     doStart = (net) ->
-      net.start (err) ->
-        return callback err
+      net.start callback
 
     network = @networks[graphName]
     if network and network.network


### PR DESCRIPTION
This makes `defaultGraph` initialization asynchronous so that callers can handle its results via events.

Also adds events to the base runtime class:

* `ready`: if defaultGraph is supplied, emitted when that network is ready. Otherwise emitted after runtime is ready
* `error`: if network can't be created for the defaultGraph

Fixes noflo/noflo#603