### PR TITLE
More consistent namespace handling

### DIFF
--- a/src/Base.js
+++ b/src/Base.js
@@ -19,6 +19,8 @@ const debugMessagingReceivePayload = require('debug')('noflo-runtime-base:messag
 const debugMessagingSend = require('debug')('noflo-runtime-base:messaging:send');
 const debugMessagingSendPayload = require('debug')('noflo-runtime-base:messaging:send:payload');
 
+const { withNamespace } = require('./utils');
+
 // This is the class all NoFlo runtime implementations can extend to easily wrap
 // into any transport protocol.
 class BaseTransport extends EventEmitter {
@@ -71,7 +73,7 @@ class BaseTransport extends EventEmitter {
   getGraphName(graph) {
     const namespace = this.options.namespace || 'default';
     const graphName = graph.name || 'main';
-    return `${namespace}/${graphName}`;
+    return withNamespace(graphName, namespace);
   }
 
   _startDefaultGraph() {

--- a/src/protocol/Component.js
+++ b/src/protocol/Component.js
@@ -128,7 +128,7 @@ class ComponentProtocol extends EventEmitter {
             && library === this.transport.options.namespace
             && !this.transport.graph.graphs[componentName]) {
             // Register subgraph also to the graph protocol handler
-            this.transport.graph.registerGraph(componentName, instance.network.graph, null, false);
+            this.transport.graph.registerGraph(component, instance.network.graph, null, false);
           }
           this.sendComponent(component, instance, context);
           callback(null);

--- a/src/protocol/Graph.js
+++ b/src/protocol/Graph.js
@@ -2,6 +2,7 @@ const noflo = require('noflo');
 const {
   EventEmitter,
 } = require('events');
+const { withNamespace } = require('../utils');
 
 class GraphProtocol extends EventEmitter {
   constructor(transport) {
@@ -127,7 +128,10 @@ class GraphProtocol extends EventEmitter {
         return;
       }
 
-      const fullName = graph.properties.library ? `${graph.properties.library}/${id}` : id;
+      const fullName = withNamespace(
+        id,
+        graph.properties.library || this.transport.options.namespace,
+      );
       // Register for runtime exported ports
       this.transport.runtime.registerNetwork(id, network);
       if (graph.name === 'main' || graph.properties.main) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -11,3 +11,17 @@ exports.parseName = function parseName(name) {
     name: nameParts[1],
   };
 };
+
+exports.withNamespace = function withNamespace(name, namespace) {
+  if (!namespace || name.indexOf('/') !== -1) {
+    return name;
+  }
+  return `${name}/${namespace}`;
+};
+
+exports.withoutNamespace = function withoutNamespace(name) {
+  if (name.indexOf('/') === -1) {
+    return name;
+  }
+  return name.split('/')[1];
+};


### PR DESCRIPTION
There are inconsistencies between how Flowhub uses graph names, and how the runtimes do.

The primary problem is when a graph is loaded by both parties independently (runtime registers network for each graph in the project via #129, Flowhub assumes the networks are there). Then we need to make sure the initial identifiers match.

* When Flowhub gets graph name from runtime (via runtime info), that name should be retained
* When Runtime gets graph name from Flowhub, that name should be retained
* When Flowhub sends graphs, they should always be namespaced
* Saving graph should normalize the name to non-namespaced form in the file
* `@something` and `noflo-` should be removed from the namespace

Refs noflo/noflo-nodejs#190
Refs noflo/noflo-ui#964

